### PR TITLE
USPS encoding issue fix for UI

### DIFF
--- a/src/Presentation/SmartStore.Web/Views/Checkout/ShippingMethod.Mobile.cshtml
+++ b/src/Presentation/SmartStore.Web/Views/Checkout/ShippingMethod.Mobile.cshtml
@@ -27,7 +27,7 @@
                             <div class="shipping-option-item">
                                 <div class="option-name">
                                     <input id="shippingoption_@(i)" type="radio" name="shippingoption" value="@(shippingMethod.Name)___@(shippingMethod.ShippingRateComputationMethodSystemName)" checked="@shippingMethod.Selected" />
-                                    <label for="shippingoption_@(i)">@shippingMethod.Name (@shippingMethod.Fee)</label>
+                                    <label for="shippingoption_@(i)">@Html.Raw(HttpUtility.HtmlDecode(shippingMethod.Name)) (@shippingMethod.Fee)</label>
                                 </div>
                                 @if (!String.IsNullOrEmpty(shippingMethod.Description))
                                 {

--- a/src/Presentation/SmartStore.Web/Views/Checkout/ShippingMethod.cshtml
+++ b/src/Presentation/SmartStore.Web/Views/Checkout/ShippingMethod.cshtml
@@ -42,7 +42,7 @@
 										<input id="shippingoption_@(i)" type="radio" name="shippingoption" class="opt-radio"
 											   @Html.Attr("checked", "checked", shippingMethod.Selected)
 											   value="@(shippingMethod.Name)___@(shippingMethod.ShippingRateComputationMethodSystemName)" />
-										<span class="opt-name">@shippingMethod.Name</span>
+                                        <span class="opt-name">@Html.Raw(HttpUtility.HtmlDecode(shippingMethod.Name))</span>
 									</label>
 								</div>
 							</div>

--- a/src/Presentation/SmartStore.Web/Views/ShoppingCart/EstimateShipping.cshtml
+++ b/src/Presentation/SmartStore.Web/Views/ShoppingCart/EstimateShipping.cshtml
@@ -88,7 +88,8 @@
                         {
                             <div class="shipping-option-item" style="margin-bottom: 8px">
                                 <div class="option-name">
-                                    @shippingOption.Name (@shippingOption.Price)
+                                    @Html.Raw(HttpUtility.HtmlDecode(shippingOption.Name))
+                                    (@shippingOption.Price)
                                 </div>
                                 <div class="option-description muted">
                                     @Html.Raw(shippingOption.Description)


### PR DESCRIPTION
USPS passes in a TM with encoded html. This fixes the display for the Priority Mail (and other) shipping methods. Based on a similar solution in a nop patch.